### PR TITLE
Return keyboard focus to main editor when canceling search

### DIFF
--- a/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
+++ b/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
@@ -100,6 +100,7 @@ namespace eXeMeL
       GalaSoft.MvvmLight.Messaging.Messenger.Default.Register<UnselectTextInEditorMessage>(this, HandleUnselectTextInEditorMessage);
       GalaSoft.MvvmLight.Messaging.Messenger.Default.Register<DocumentTextReplacedMessage>(this, HandleDocumentTextReplacedMessage);
       GalaSoft.MvvmLight.Messaging.Messenger.Default.Register<ApplicationThemeUpdatedMessage>(this, HandleApplicationThemeUpdatedMessage);
+      GalaSoft.MvvmLight.Messaging.Messenger.Default.Register<SetKeyboardFocusToEditor>(this, HandleSetKeyboardFocusToEditorMessage);
 
       this.ViewModel.Editor.RefreshComplete += Editor_RefreshComplete;
       this.ViewModel.Editor.PropertyChanging += Editor_PropertyChanging;
@@ -304,7 +305,11 @@ namespace eXeMeL
       SetWindowGlow();
     }
 
-
+    private void HandleSetKeyboardFocusToEditorMessage(SetKeyboardFocusToEditor obj)
+    {
+      this.ResetFocusCommand.Execute(null);
+    }
+    
 
     private void SetWindowGlow()
     {

--- a/src/eXeMeL/eXeMeL/Messages/SetKeyboardFocusToEditor.cs
+++ b/src/eXeMeL/eXeMeL/Messages/SetKeyboardFocusToEditor.cs
@@ -1,0 +1,6 @@
+﻿namespace eXeMeL.Messages
+{
+  public class SetKeyboardFocusToEditor
+  {
+  }
+}

--- a/src/eXeMeL/eXeMeL/ViewModel/EditorFindViewModel.cs
+++ b/src/eXeMeL/eXeMeL/ViewModel/EditorFindViewModel.cs
@@ -394,6 +394,7 @@ namespace eXeMeL.ViewModel
 
     private void CancelSearch()
     {
+      this.MessengerInstance.Send(new SetKeyboardFocusToEditor());
       this.MessengerInstance.Send(new DisplayToolInformationMessage(string.Empty));
     }
 

--- a/src/eXeMeL/eXeMeL/eXeMeL.csproj
+++ b/src/eXeMeL/eXeMeL/eXeMeL.csproj
@@ -146,6 +146,7 @@
     <Compile Include="ViewModel\DocumentSnapshot.cs" />
     <Compile Include="ViewModel\EditorViewModel.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
+    <Compile Include="Messages\SetKeyboardFocusToEditor.cs" />
     <Compile Include="ViewModel\SyntaxHighlightManager.cs" />
     <Compile Include="ViewModel\ViewModelLocator.cs" />
     <Compile Include="ViewModel\XmlCleaners\FormatCleaner.cs" />


### PR DESCRIPTION
Canceling the search, with the <kbd>Esc</kbd> key, returns keyboard focus and control to the main editor. This is a fix for issue #23