### PR TITLE
Fix build warning and vpk icon path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Package with Velopack
         run: |
-          vpk pack --packId eXeMeL --packVersion ${{ steps.version.outputs.VERSION }} --packDir publish --mainExe eXeMeL.exe --icon src/eXeMeL/eXeMeL/Assets/eXeMeL_Icon.ico
+          vpk pack --packId eXeMeL --packVersion ${{ steps.version.outputs.VERSION }} --packDir publish --mainExe eXeMeL.exe --icon "src/eXeMeL/eXeMeL/Assets/eXeMeL Icon.ico"
 
       - name: Upload to GitHub Releases
         run: |

--- a/src/eXeMeL/eXeMeL/ViewModel/JsonCleaners/JsonSurroundingGarbageCleaner.cs
+++ b/src/eXeMeL/eXeMeL/ViewModel/JsonCleaners/JsonSurroundingGarbageCleaner.cs
@@ -16,7 +16,6 @@ namespace eXeMeL.ViewModel.JsonCleaners
       int firstBracket = text.IndexOf('[');
 
       int start;
-      char openChar;
       char closeChar;
 
       if (firstBrace < 0 && firstBracket < 0)
@@ -25,25 +24,21 @@ namespace eXeMeL.ViewModel.JsonCleaners
       if (firstBrace < 0)
       {
         start = firstBracket;
-        openChar = '[';
         closeChar = ']';
       }
       else if (firstBracket < 0)
       {
         start = firstBrace;
-        openChar = '{';
         closeChar = '}';
       }
       else if (firstBrace < firstBracket)
       {
         start = firstBrace;
-        openChar = '{';
         closeChar = '}';
       }
       else
       {
         start = firstBracket;
-        openChar = '[';
         closeChar = ']';
       }
 


### PR DESCRIPTION
- Remove unused openChar variable in JsonSurroundingGarbageCleaner
- Fix icon path in release workflow: "eXeMeL Icon.ico" (has a space, was incorrectly "eXeMeL_Icon.ico" with underscore)