### PR TITLE
Add update toast notification on startup

### DIFF
--- a/src/eXeMeL/eXeMeL/App.xaml.cs
+++ b/src/eXeMeL/eXeMeL/App.xaml.cs
@@ -48,8 +48,7 @@ namespace eXeMeL
         StartupOptions.InitialFilePath = e.Args[0];
       }
 
-      // Auto-check for updates on startup (non-blocking)
-      _ = CheckForUpdatesAsync(silent: true);
+      // Update check is triggered by MainWindow.Loaded → CheckForUpdatesOnStartup()
     }
 
     /// <summary>

--- a/src/eXeMeL/eXeMeL/MainWindow.xaml
+++ b/src/eXeMeL/eXeMeL/MainWindow.xaml
@@ -231,6 +231,7 @@
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="*"/>
         <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
 
       <!-- Tab header row + Snapshots -->
@@ -444,8 +445,37 @@
         </Border>
       </Grid>
 
+      <!-- Update toast notification -->
+      <Border x:Name="UpdateToast" Grid.Row="2" Visibility="Collapsed"
+              Background="{DynamicResource AppAccentBrush}" Padding="12,8"
+              CornerRadius="0">
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+          </Grid.ColumnDefinitions>
+          <TextBlock x:Name="UpdateToastMessage" Grid.Column="0"
+                     Text="A new version is available!"
+                     VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold"
+                     Foreground="#FF1E1E1E"/>
+          <Button Grid.Column="1" Content="Update now and restart"
+                  Click="UpdateNowButton_Click" Margin="8,0"
+                  Padding="10,4" FontSize="12" Cursor="Hand"/>
+          <Button Grid.Column="2" Content="Update later"
+                  Click="UpdateLaterButton_Click" Margin="0,0,8,0"
+                  Padding="10,4" FontSize="12" Cursor="Hand"/>
+          <Button Grid.Column="3" Content="&#xE10A;" FontFamily="Segoe MDL2 Assets"
+                  Click="UpdateDismissButton_Click"
+                  Background="Transparent" BorderThickness="0"
+                  Padding="4" FontSize="10" Cursor="Hand"
+                  Foreground="#FF1E1E1E" VerticalAlignment="Center"/>
+        </Grid>
+      </Border>
+
       <!-- Footer / Status Bar with gold accent -->
-      <Border Grid.Row="2" Padding="12,6"
+      <Border Grid.Row="3" Padding="12,6"
               BorderThickness="0,1,0,0" BorderBrush="{DynamicResource AppAccentBrush}">
         <Grid>
           <Grid.ColumnDefinitions>

--- a/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
+++ b/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace eXeMeL
       {
         ApplyWindowChrome();
         UpdateCurrentLineHighlight();
+        CheckForUpdatesOnStartup();
       };
 
       this.AvalonEditor.PreviewKeyDown += AvalonEditor_PreviewKeyDown;
@@ -800,6 +801,38 @@ namespace eXeMeL
     {
       this.ResetFocusCommand.Execute(null);
     }
+
+
+
+    #region Update Toast
+
+    private async void CheckForUpdatesOnStartup()
+    {
+      var hasUpdate = await App.CheckForUpdatesAsync(silent: true);
+      if (hasUpdate && App.LatestUpdate != null)
+      {
+        this.UpdateToastMessage.Text = $"eXeMeL {App.LatestUpdate.TargetFullRelease.Version} is available!";
+        this.UpdateToast.Visibility = Visibility.Visible;
+      }
+    }
+
+    private async void UpdateNowButton_Click(object sender, RoutedEventArgs e)
+    {
+      this.UpdateToastMessage.Text = "Downloading update...";
+      await App.ApplyUpdateAsync();
+    }
+
+    private void UpdateLaterButton_Click(object sender, RoutedEventArgs e)
+    {
+      this.UpdateToast.Visibility = Visibility.Collapsed;
+    }
+
+    private void UpdateDismissButton_Click(object sender, RoutedEventArgs e)
+    {
+      this.UpdateToast.Visibility = Visibility.Collapsed;
+    }
+
+    #endregion
 
 
 


### PR DESCRIPTION
- Toast bar appears above the status bar when an update is found
- Shows version number: "eXeMeL X.Y.Z is available!"
- Three actions: "Update now and restart", "Update later", X dismiss
- "Update now" downloads and restarts via Velopack
- "Update later" and X both dismiss the toast
- Update check triggered in MainWindow.Loaded (non-blocking async)
- Removed duplicate check from App.OnStartup
- Next app launch will check again
- Added Grid.Row="3" for footer, Row="2" for toast