### PR TITLE
Add DEBUG bypass for update toast testing

### DIFF
--- a/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
+++ b/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
@@ -808,18 +808,37 @@ namespace eXeMeL
 
     private async void CheckForUpdatesOnStartup()
     {
+#if DEBUG
+      // Debug bypass: show fake toast to test UI without a real update
+      await System.Threading.Tasks.Task.Delay(1500); // Simulate network delay
+      this.UpdateToastMessage.Text = "eXeMeL 2.99.0 is available! (DEBUG)";
+      this.UpdateToast.Visibility = Visibility.Visible;
+      return;
+#endif
+
+#pragma warning disable CS0162 // Unreachable code
       var hasUpdate = await App.CheckForUpdatesAsync(silent: true);
       if (hasUpdate && App.LatestUpdate != null)
       {
         this.UpdateToastMessage.Text = $"eXeMeL {App.LatestUpdate.TargetFullRelease.Version} is available!";
         this.UpdateToast.Visibility = Visibility.Visible;
       }
+#pragma warning restore CS0162
     }
 
     private async void UpdateNowButton_Click(object sender, RoutedEventArgs e)
     {
+#if DEBUG
+      this.UpdateToastMessage.Text = "Downloading update... (DEBUG - no actual update)";
+      await System.Threading.Tasks.Task.Delay(2000);
+      this.UpdateToast.Visibility = Visibility.Collapsed;
+      return;
+#endif
+
+#pragma warning disable CS0162
       this.UpdateToastMessage.Text = "Downloading update...";
       await App.ApplyUpdateAsync();
+#pragma warning restore CS0162
     }
 
     private void UpdateLaterButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- In DEBUG builds: shows fake toast after 1.5s delay with "eXeMeL 2.99.0 is available! (DEBUG)" message
- "Update now" simulates a 2s download then dismisses
- Bypasses real Velopack check entirely in debug mode
- Release builds use the real update flow unchanged
- #pragma warning disable CS0162 suppresses unreachable code warning