### PR TITLE
Move settings to eXeMeL2 directory and fix text color readability on …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The app follows MVVM using **CommunityToolkit.Mvvm** (migrated from MvvmLight). 
 | Editor logic | `ViewModel/EditorViewModel.cs` | Clipboard ops, XML cleaning pipeline, snapshots, file I/O |
 | XPath utility | `ViewModel/XmlUtility/XmlUtilityViewModel.cs` | XPath evaluation and tree navigation |
 | XML cleaners | `ViewModel/XmlCleaners/` | Chain of cleaners (URL encoding, trim, newlines, VS artifacts, formatting) |
-| Settings | `Model/Settings.cs`, `Model/SettingsIO.cs` | User preferences persisted as JSON to `%LOCALAPPDATA%\eXeMeL\settings.json` |
+| Settings | `Model/Settings.cs`, `Model/SettingsIO.cs` | User preferences persisted as JSON to `%LOCALAPPDATA%\eXeMeL2\settings.json` |
 | Settings migration | `Model/SettingsMigrator.cs` | Auto-migrates old Registry settings to file on first run |
 | Syntax themes | `Assets/SyntaxHighlightingSchemes/` | AvalonEdit `.xshd` files (VSBlue, Dark, Bright, Earthy, SolarizedDark) |
 | Theme manager | `ViewModel/SyntaxHighlightManager.cs` | Swaps theme ResourceDictionaries using marker-key approach |
@@ -74,7 +74,7 @@ The app follows MVVM using **CommunityToolkit.Mvvm** (migrated from MvvmLight). 
 
 ### Settings Storage
 
-Settings persist as JSON to `%LOCALAPPDATA%\eXeMeL\settings.json` using `System.Text.Json`. On first run, `SettingsMigrator` checks for old Registry settings at `HKCU\Software\eXeMeL` and migrates them automatically.
+Settings persist as JSON to `%LOCALAPPDATA%\eXeMeL2\settings.json` using `System.Text.Json`. On first run, `SettingsMigrator` checks for old Registry settings at `HKCU\Software\eXeMeL` and migrates them automatically.
 
 ### Theme System
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A desktop XML editor for Windows, built for developers who work with XML daily. 
 
 ### Download
 
-Download `eXeMeL.exe` from the latest release. No installation or .NET runtime required — it's a self-contained executable.
+Download either the intallable or stand-alone version of eXeMeL from the latest release.
 
 ### Build from source
 
@@ -63,7 +63,7 @@ dotnet test eXeMeL.Tests\eXeMeL.Tests.csproj
 
 ## Settings
 
-User settings are stored at `%LOCALAPPDATA%\eXeMeL\settings.json`. If upgrading from an older version that stored settings in the Windows Registry (`HKCU\Software\eXeMeL`), they are migrated automatically on first launch.
+User settings are stored at `%LOCALAPPDATA%\eXeMeL2\settings.json`. If upgrading from an older version that stored settings in the Windows Registry (`HKCU\Software\eXeMeL`), they are migrated automatically on first launch.
 
 ## Technology Stack
 
@@ -98,7 +98,7 @@ This application was originally built circa 2013 on .NET Framework 4.5. In April
 - Command-line file argument replaces ClickOnce activation
 
 ### Settings storage
-- Windows Registry (`HKCU\Software\eXeMeL`) replaced with local JSON file (`%LOCALAPPDATA%\eXeMeL\settings.json`)
+- Windows Registry (`HKCU\Software\eXeMeL`) replaced with local JSON file (`%LOCALAPPDATA%\eXeMeL2\settings.json`)
 - Automatic one-time migration from Registry on first run
 - `System.Text.Json` replaces `DataContractJsonSerializer`
 

--- a/src/eXeMeL/eXeMeL/Model/Settings.cs
+++ b/src/eXeMeL/eXeMeL/Model/Settings.cs
@@ -19,7 +19,7 @@ namespace eXeMeL.Model
     private string _fontFamily;
     private bool _highlightOtherInstancesOfSelection;
     private string _chromeTintColor = "#3366CC";
-    private string _textColor = "#FFFFFF";
+    private string _textColor;
     private string _accentColor = "#D4AA00";
     private double _editorTintIntensity = 0.3;
     private double _chromeOpacity = 0.5;
@@ -235,7 +235,7 @@ namespace eXeMeL.Model
       FontFamily = "Consolas";
       HighlightOtherInstancesOfSelection = true;
       ChromeTintColor = "#3366CC";
-      TextColor = "#FFFFFF";
+      TextColor = null;
       AccentColor = "#D4AA00";
       EditorTintIntensity = 0.3;
       ChromeOpacity = 0.5;

--- a/src/eXeMeL/eXeMeL/Model/SettingsIO.cs
+++ b/src/eXeMeL/eXeMeL/Model/SettingsIO.cs
@@ -8,6 +8,9 @@ namespace eXeMeL.Model
   internal static class SettingsIO
   {
     private static readonly string SettingsDirectory =
+      Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "eXeMeL2");
+
+    private static readonly string LegacySettingsDirectory =
       Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "eXeMeL");
 
     private static readonly string SettingsFilePath =
@@ -22,6 +25,9 @@ namespace eXeMeL.Model
 
 
     public static string GetSettingsFilePath() => SettingsFilePath;
+
+    public static string GetLegacySettingsFilePath() =>
+      Path.Combine(LegacySettingsDirectory, "settings.json");
 
 
     public static void SaveSettings(Settings settings)

--- a/src/eXeMeL/eXeMeL/Model/SettingsMigrator.cs
+++ b/src/eXeMeL/eXeMeL/Model/SettingsMigrator.cs
@@ -16,6 +16,24 @@ namespace eXeMeL.Model
     {
       var settingsFilePath = SettingsIO.GetSettingsFilePath();
 
+      // Move settings from the old %LOCALAPPDATA%\eXeMeL directory if present
+      if (!File.Exists(settingsFilePath))
+      {
+        var legacyFilePath = SettingsIO.GetLegacySettingsFilePath();
+        if (File.Exists(legacyFilePath))
+        {
+          try
+          {
+            Directory.CreateDirectory(Path.GetDirectoryName(settingsFilePath));
+            File.Move(legacyFilePath, settingsFilePath);
+          }
+          catch (Exception)
+          {
+            // If the move fails, fall through to the registry migration or defaults
+          }
+        }
+      }
+
       if (File.Exists(settingsFilePath))
       {
         return;

--- a/src/eXeMeL/eXeMeL/View/ColorPickerPopup.xaml.cs
+++ b/src/eXeMeL/eXeMeL/View/ColorPickerPopup.xaml.cs
@@ -12,11 +12,15 @@ namespace eXeMeL.View
 
     public static readonly DependencyProperty SelectedColorProperty =
       DependencyProperty.Register(nameof(SelectedColor), typeof(string), typeof(ColorPickerPopup),
-        new FrameworkPropertyMetadata("#D4AA00", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedColorChanged));
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedColorChanged));
 
     public static readonly DependencyProperty SwatchColorsProperty =
       DependencyProperty.Register(nameof(SwatchColors), typeof(string[]), typeof(ColorPickerPopup),
         new PropertyMetadata(null, OnSwatchColorsChanged));
+
+    public static readonly DependencyProperty ThemeResourceKeyProperty =
+      DependencyProperty.Register(nameof(ThemeResourceKey), typeof(string), typeof(ColorPickerPopup),
+        new PropertyMetadata(null));
 
     public string SelectedColor
     {
@@ -28,6 +32,16 @@ namespace eXeMeL.View
     {
       get => (string[])GetValue(SwatchColorsProperty);
       set => SetValue(SwatchColorsProperty, value);
+    }
+
+    /// <summary>
+    /// When SelectedColor is null, the picker displays the color from this application resource key
+    /// (e.g. "AppTextBrush") so the user sees the effective theme default.
+    /// </summary>
+    public string ThemeResourceKey
+    {
+      get => (string)GetValue(ThemeResourceKeyProperty);
+      set => SetValue(ThemeResourceKeyProperty, value);
     }
 
     public ColorPickerPopup()
@@ -101,16 +115,34 @@ namespace eXeMeL.View
       _updatingFromSlider = false;
     }
 
+    private string GetEffectiveColor()
+    {
+      if (!string.IsNullOrEmpty(SelectedColor))
+        return SelectedColor;
+
+      // Resolve the current theme's default from the resource dictionary
+      if (!string.IsNullOrEmpty(ThemeResourceKey)
+          && Application.Current?.Resources[ThemeResourceKey] is SolidColorBrush themeBrush)
+      {
+        var c = themeBrush.Color;
+        return $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+      }
+
+      return null;
+    }
+
     private void UpdateVisuals()
     {
+      var effectiveColor = GetEffectiveColor();
       try
       {
-        var color = (Color)ColorConverter.ConvertFromString(SelectedColor);
+        if (effectiveColor == null) return;
+        var color = (Color)ColorConverter.ConvertFromString(effectiveColor);
         var brush = new SolidColorBrush(color);
         brush.Freeze();
         if (ColorSwatchButton != null) ColorSwatchButton.Background = brush;
         if (PreviewSwatch != null) PreviewSwatch.Background = brush;
-        if (HexLabel != null) HexLabel.Text = SelectedColor;
+        if (HexLabel != null) HexLabel.Text = effectiveColor;
       }
       catch { }
 
@@ -132,7 +164,9 @@ namespace eXeMeL.View
       if (HueSlider == null) return;
       try
       {
-        var color = (Color)ColorConverter.ConvertFromString(SelectedColor);
+        var effectiveColor = GetEffectiveColor();
+        if (effectiveColor == null) return;
+        var color = (Color)ColorConverter.ConvertFromString(effectiveColor);
         var (h, s, v) = ColorToHsv(color);
         HueSlider.Value = h;
         SatSlider.Value = s * 100;

--- a/src/eXeMeL/eXeMeL/View/SettingsView.xaml
+++ b/src/eXeMeL/eXeMeL/View/SettingsView.xaml
@@ -163,7 +163,8 @@
         <TextBlock Text="Text Color" FontSize="14"/>
       </ui:CardControl.Header>
       <views:ColorPickerPopup SelectedColor="{Binding TextColor, Mode=TwoWay}"
-                               SwatchColors="{x:Static views:ColorSwatches.TextColors}"/>
+                               SwatchColors="{x:Static views:ColorSwatches.TextColors}"
+                               ThemeResourceKey="AppTextBrush"/>
     </ui:CardControl>
 
     <ui:CardControl Margin="0,0,0,4">
@@ -171,7 +172,8 @@
         <TextBlock Text="Accent Color" FontSize="14"/>
       </ui:CardControl.Header>
       <views:ColorPickerPopup SelectedColor="{Binding AccentColor, Mode=TwoWay}"
-                               SwatchColors="{x:Static views:ColorSwatches.AccentColors}"/>
+                               SwatchColors="{x:Static views:ColorSwatches.AccentColors}"
+                               ThemeResourceKey="AppAccentBrush"/>
     </ui:CardControl>
 
     <!-- Reset -->

--- a/src/eXeMeL/eXeMeL/ViewModel/SyntaxHighlightManager.cs
+++ b/src/eXeMeL/eXeMeL/ViewModel/SyntaxHighlightManager.cs
@@ -162,19 +162,33 @@ namespace eXeMeL.ViewModel
           .FirstOrDefault(d => d.Contains("IsEXeMeLTheme"));
       if (existingDict == null) return;
 
+      ApplyUserColors(existingDict, settings);
+    }
+
+    private static void ApplyUserColors(ResourceDictionary dict, Settings settings)
+    {
+      // Only override theme defaults when the user has explicitly chosen a color.
+      // Null means "not set" (e.g. migrated from an older version without this setting),
+      // so we let the theme's built-in AppTextBrush provide a readable default.
       try
       {
-        var textBrush = new System.Windows.Media.SolidColorBrush(
-          (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(settings.TextColor));
-        textBrush.Freeze();
-        existingDict["AppTextBrush"] = textBrush;
+        if (!string.IsNullOrEmpty(settings.TextColor))
+        {
+          var textBrush = new System.Windows.Media.SolidColorBrush(
+            (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(settings.TextColor));
+          textBrush.Freeze();
+          dict["AppTextBrush"] = textBrush;
+        }
 
-        var accentBrush = new System.Windows.Media.SolidColorBrush(
-          (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(settings.AccentColor));
-        accentBrush.Freeze();
-        existingDict["AppAccentBrush"] = accentBrush;
+        if (!string.IsNullOrEmpty(settings.AccentColor))
+        {
+          var accentBrush = new System.Windows.Media.SolidColorBrush(
+            (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(settings.AccentColor));
+          accentBrush.Freeze();
+          dict["AppAccentBrush"] = accentBrush;
+        }
       }
-      catch { }
+      catch { /* Invalid color string — leave theme defaults */ }
     }
 
     private static void HandleChromeTintColorChange(Settings settings)
@@ -285,20 +299,7 @@ namespace eXeMeL.ViewModel
       }
       Wpf.Ui.Appearance.ApplicationThemeManager.Apply(wpfUiTheme);
 
-      // Apply user text and accent colors
-      try
-      {
-        var textBrush = new System.Windows.Media.SolidColorBrush(
-          (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(this.Settings.TextColor));
-        textBrush.Freeze();
-        dict["AppTextBrush"] = textBrush;
-
-        var accentBrush = new System.Windows.Media.SolidColorBrush(
-          (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(this.Settings.AccentColor));
-        accentBrush.Freeze();
-        dict["AppAccentBrush"] = accentBrush;
-      }
-      catch { }
+      ApplyUserColors(dict, this.Settings);
     }
 
 


### PR DESCRIPTION
…theme mismatch

- Change settings directory from %LOCALAPPDATA%\eXeMeL to %LOCALAPPDATA%\eXeMeL2
- Auto-migrate settings file from old location on first run
- Default TextColor to null (theme-provided) instead of hardcoded #FFFFFF, so migrated settings from older versions without TextColor get a readable default for their selected theme (e.g. dark text on Light theme)
- Skip overriding AppTextBrush/AppAccentBrush when user hasn't explicitly chosen a color, letting the theme ResourceDictionary provide the default
- Fix ColorPickerPopup showing accent gold (#D4AA00) when TextColor is null by resolving the effective color from the theme resource via ThemeResourceKey