### PR TITLE
Defer update check 5 seconds after startup to avoid competing with co…

### DIFF
--- a/src/eXeMeL/eXeMeL/App.xaml.cs
+++ b/src/eXeMeL/eXeMeL/App.xaml.cs
@@ -25,7 +25,9 @@ namespace eXeMeL
     [STAThread]
     private static void Main(string[] args)
     {
-      // Velopack MUST be first — handles install/uninstall/update hooks
+      // Velopack lifecycle hooks — MUST run first.
+      // Only does work when invoked by the installer (special args);
+      // returns immediately during normal user launches.
       VelopackApp.Build()
         .Run();
 

--- a/src/eXeMeL/eXeMeL/Assets/ChangeLog.txt
+++ b/src/eXeMeL/eXeMeL/Assets/ChangeLog.txt
@@ -1,5 +1,6 @@
-﻿*4/16/2026 - Improved readability
+﻿*4/16/2026 - Improved startup time and readability
 
+- Improved startup time by delaying update checks
 - Added ability to control color of the editor's background to enhance readability.
 - Added default text colors for application themes to prevent too similar of a color being defaulted for light on light or dark on dark.
 

--- a/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
+++ b/src/eXeMeL/eXeMeL/MainWindow.xaml.cs
@@ -954,9 +954,10 @@ namespace eXeMeL
 
     private async void CheckForUpdatesOnStartup()
     {
+      // Delay update check so it doesn't compete with initial content load
+      await System.Threading.Tasks.Task.Delay(5000);
+
 #if DEBUG
-      // Debug bypass: show fake toast to test UI without a real update
-      await System.Threading.Tasks.Task.Delay(1500); // Simulate network delay
       this.UpdateToastMessage.Text = "eXeMeL 2.99.0 is available! (DEBUG)";
       this.UpdateToast.Visibility = Visibility.Visible;
       return;


### PR DESCRIPTION
…ntent load

The Velopack update check (CheckForUpdatesOnStartup) was firing immediately on Loaded, causing DNS resolution and HTTPS connections to GitHub while the clipboard content was still being cleaned and rendered. Added a 5-second delay so the app fully loads before any network I/O begins. VelopackApp.Build().Run() stays first as required but is documented as instant during normal launches.